### PR TITLE
Dev emi/front/feature/admin/paquetes

### DIFF
--- a/Front/src/api/packageApi.js
+++ b/Front/src/api/packageApi.js
@@ -1,3 +1,4 @@
+// src/api/packageApi.js
 import { PACKAGES_ENDPOINT } from "../constants";
 import apiClient from "./apiClient";
 
@@ -39,3 +40,21 @@ export const deleteDepartureFromPackage = ( packageId, departureId ) => {
 export const getAllActivesPackages = (paginated = {}) => {
     return apiClient.get(`${PACKAGES_ENDPOINT}/actives`, { skipAuth: true , params: paginated });
 };
+
+// Enviar una imagen para Banner o Itinerary de un paquete.       POST /packages/{packageId}/update-image
+export const postSimpleImagePackages = (packageId, formData) => {
+    return apiClient.post(`${PACKAGES_ENDPOINT}/${packageId}/update-image`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+  };
+
+// Enviar una imagen para Banner o Itinerary de un paquete.       POST /packages/{packageId}/update-image
+export const postImagesPackages = (packageId, formData) => {
+    return apiClient.post(`${PACKAGES_ENDPOINT}/${packageId}/add-image`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+  };

--- a/Front/src/components/Home/Footer.jsx
+++ b/Front/src/components/Home/Footer.jsx
@@ -1,12 +1,11 @@
-import React, { forwardRef } from "react";
+// Front/src/components/Home/Footer.jsx
+import { forwardRef } from "react";
 import { Box, Divider, Typography, Grid2, Link } from "@mui/material";
-import logo from "../../assets/logo.png";
+import logo from "@/assets/logo.png";
 import { RiInstagramFill, RiTiktokFill, RiWhatsappFill } from "react-icons/ri";
 
 const Footer = forwardRef((props, ref) => {
 const currentYear = new Date().getFullYear();
-
-console.log('ref', ref)
 
   return (
       <Box

--- a/Front/src/components/Home/NavBar.jsx
+++ b/Front/src/components/Home/NavBar.jsx
@@ -121,7 +121,7 @@ const NavBar = ({ isAdmin = false, setIsOpenDrawer, isOpenDrawer = false, isDraw
           <Typography variant="paragraphLight" onClick={()=>navigate("/salidas")} sx={{...styledMenuItem, color: location.split('/')[1] === "salidas" ? '#FFC800' : 'fff',}}>Salidas</Typography>
           <Typography variant="paragraphLight" onClick={()=>navigate("/about")} sx={{...styledMenuItem, color: location.split('/')[1] === "about" ? '#FFC800' : 'fff',}}>Quienes somos</Typography>
           <Typography variant="paragraphLight" onClick={()=>navigate("/destinos")} sx={{...styledMenuItem, color : location.split('/')[1] === "destinos" ? '#FFC800' : 'fff',}}>Destinos</Typography>
-          <Typography variant="paragraphLight" onClick={()=>navigate("/gallery")} sx={{...styledMenuItem, color: location.split('/')[1] === "gallery" ? '#FFC800' : 'fff',}}>Galería</Typography>
+          {/* <Typography variant="paragraphLight" onClick={()=>navigate("/gallery")} sx={{...styledMenuItem, color: location.split('/')[1] === "gallery" ? '#FFC800' : 'fff',}}>Galería</Typography> */}
           <Typography variant="paragraphLight" onClick={()=>navigate("/contacto")} sx={{...styledMenuItem, color : location.split('/')[1] === "contacto" ? '#FFC800' : 'fff',}}>Contacto</Typography>
 
           {isAdmin && (
@@ -153,7 +153,7 @@ const NavBar = ({ isAdmin = false, setIsOpenDrawer, isOpenDrawer = false, isDraw
           <Typography onClick={()=>handleNavigation("/salidas")} variant="paragraphLight" sx={{...styledMenuItem, color: location.split('/')[1] === "salidas" ? '#FFC800' : 'fff',}}>Salidas</Typography>
           <Typography onClick={()=>handleNavigation("/about")} variant="paragraphLight" sx={{...styledMenuItem, color: location.split('/')[1] === "about" ? '#FFC800' : 'fff',}}>Quienes somos</Typography>
           <Typography onClick={()=>handleNavigation("/destinos")} variant="paragraphLight" sx={{...styledMenuItem, color : location.split('/')[1] === "destinos" ? '#FFC800' : 'fff',}}>Destinos</Typography>
-          <Typography onClick={()=>handleNavigation("/gallery")} variant="paragraphLight" sx={{...styledMenuItem, color: location.split('/')[1] === "gallery" ? '#FFC800' : 'fff',}}>Galería</Typography>
+          {/* <Typography onClick={()=>handleNavigation("/gallery")} variant="paragraphLight" sx={{...styledMenuItem, color: location.split('/')[1] === "gallery" ? '#FFC800' : 'fff',}}>Galería</Typography> */}
           <Typography onClick={()=>handleNavigation("/contacto")} variant="paragraphLight" sx={{...styledMenuItem, color : location.split('/')[1] === "contacto" ? '#FFC800' : 'fff',}}>Contacto</Typography>
 
           {isAdmin && (

--- a/Front/src/modules/Departures/components/CommentsCards.jsx
+++ b/Front/src/modules/Departures/components/CommentsCards.jsx
@@ -1,16 +1,15 @@
+// Front/src/modules/Departures/components/CommentsCards.jsx
 import { Stack, Typography, Box } from "@mui/material";
-import { customPalette } from "../../../../customStyle";
 import PropTypes from "prop-types"; 
 
 import {AccountCircle} from "@mui/icons-material";
-import IconButton from '@mui/material/IconButton';
-import { formatDateAndHour } from '../utils/utils.jsx';
+import { formatDateAndHour } from '@modules/Departures/utils/utils.jsx';
 export default function CommentsCards({ user, text, date, packageName }) {
 
   CommentsCards.propTypes = {
     user: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
-    date: PropTypes.array.isRequired,
+    date: PropTypes.string.isRequired,
   };
 
 
@@ -18,7 +17,7 @@ export default function CommentsCards({ user, text, date, packageName }) {
     <Stack
       sx={{
         padding: "1rem",
-        backgroundColor: customPalette.text.light,
+        backgroundColor: "#F3F3F3",
         borderRadius: "8px",
         width: "95%",
         height: "fit-content",

--- a/Front/src/modules/Departures/components/DepartureCard.jsx
+++ b/Front/src/modules/Departures/components/DepartureCard.jsx
@@ -57,7 +57,6 @@ export const DepartureCard = ({ pack, isAdmin = false }) => {
     </Label>
   );
 
-console.log(pack)
   return (
     <>
       <Card

--- a/Front/src/modules/admin/components/PackagesBreadCrumbs.jsx
+++ b/Front/src/modules/admin/components/PackagesBreadCrumbs.jsx
@@ -1,22 +1,47 @@
 // @modules/admin/components/PackagesBreadCrumbs.jsx
 import { Box, Divider, styled, Typography, useTheme } from "@mui/material";
 import { LuCheck } from "react-icons/lu";
+import { useNavigate, useParams } from "react-router-dom";
 
 export const PackagesBreadCrumbs = ({ step = 1 }) => {
   const theme = useTheme();
   const { palette } = theme;
+  const params = useParams();
+  const packageId = params?.id || null;
+  const navigate = useNavigate();
+
+  const handleClick = (step) => {
+    if (!packageId) return;
+    if (step === 1) return navigate(`/admin/paquetes/basico/${packageId}`);
+    if (step === 2) return navigate(`/admin/paquetes/detalles/${packageId}`);
+    if (step === 3) return navigate(`/admin/paquetes/destinos/${packageId}`);
+  };
 
   return (
     <Box sx={{ display: "flex", gap: "1rem", alignItems: "center" }}>
       {/* Paso 1 - Información General */}
-      <Box sx={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <Box 
+        sx={{ 
+          display: "flex", 
+          gap: "1rem", 
+          alignItems: "center",
+          cursor: !packageId || step === 1 ? 'not-pointer' : 'pointer'
+        }}
+        onClick={() => handleClick(1)}
+      >
         <StyledPoint
           sx={{
             color: step >= 1 ? palette.primary.main : palette.grey[50],
             backgroundColor: step === 1 ? "var(--bg-hover-links)" : step > 1 ? "#72CCA0" : palette.grey[300],
+            justifyContent: 'center',
+            alignItems: 'center'
           }}
         >
-          <Typography variant="titleH3">{step > 1 ? <LuCheck size={20}/> : 1}</Typography>
+          {step > 1 
+            ? <LuCheck size={24} color="#080808"/> 
+            : <Typography variant="titleH3">1</Typography>
+          }
+          
         </StyledPoint>
         <Typography variant="callToAction" sx={{ color: palette.grey[50] }}>
           Información General
@@ -25,7 +50,15 @@ export const PackagesBreadCrumbs = ({ step = 1 }) => {
       {/* Divider */}
       <StyledDivider />
       {/* Paso 2 - Paquete */}
-      <Box sx={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <Box 
+        sx={{ 
+          display: "flex", 
+          gap: "1rem", 
+          alignItems: "center",
+          cursor: !packageId || step === 2 ? 'not-pointer' : 'pointer'
+        }}
+        onClick={() => handleClick(2)}
+      >
         <StyledPoint
           sx={{
             color: step >= 2 ? palette.primary.main : palette.grey[50],
@@ -41,7 +74,15 @@ export const PackagesBreadCrumbs = ({ step = 1 }) => {
       {/* Divider */}
       <StyledDivider />
       {/* Paso 3 - Destino */}
-      <Box sx={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <Box 
+        sx={{ 
+          display: "flex", 
+          gap: "1rem", 
+          alignItems: "center",
+          cursor: !packageId || step === 3 ? 'not-pointer' : 'pointer'
+        }}
+        onClick={() => handleClick(3)}
+      >
         <StyledPoint
           sx={{
             color: step >= 3 ? palette.primary.main : palette.grey[50],

--- a/Front/src/modules/admin/pages/AdminPackages.jsx
+++ b/Front/src/modules/admin/pages/AdminPackages.jsx
@@ -94,7 +94,7 @@ export const AdminPackages = () => {
                 category={categories[index]} 
                 destination={item} 
                 key={item.id} 
-                route='/admin/paquetes/' 
+                route='/admin/paquetes/basico/' 
               />
             ))
           ))}

--- a/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
@@ -50,6 +50,7 @@ export const CreateEditPackageBasic = () => {
     bannerPhoto: {},
   });
   const [formModified, setFormModified] = useState(false);
+  const [newIdPackage, setNewIdPackage] = useState(null);
 
   const params = useParams();
   const navigate = useNavigate();
@@ -139,7 +140,7 @@ export const CreateEditPackageBasic = () => {
     }
   }, []);
 
-  const sendPackages = useCallback(async (values) => {
+  const sendCreatePackages = useCallback(async (values) => {
     setDisabledButton(true);
     try {
       const formData = new FormData();
@@ -157,27 +158,51 @@ export const CreateEditPackageBasic = () => {
         formData.append("filesImages", imagen);
       });
       
-      const { data: dataPackage } = params.id
-        ? await updatePackage(params.id, formData)
-        : await createPackage(formData);
+      const { data: dataPackage } = await createPackage(formData);
+      const newId = dataPackage.data.id;
+      setNewIdPackage(newId); // Actualiza el estado
+      NotificationService.success(`Paquete creado exitosamente`, 1000);
       
-      NotificationService.success(
-        `Paquete ${params.id ? "actualizado" : "creado"} exitosamente`,
-        1000
-      );
+      return newId; // Devuelve el ID del paquete creado
     } catch (error) {
-      console.error(
-        `Error al ${params.id ? "actualizar" : "crear"} el paquete:`,
-        error
-      );
-      NotificationService.error(
-        `Error al ${params.id ? "actualizar" : "crear"} el paquete`,
-        2200
-      );
+      console.error(`Error al crear el paquete:`,  error);
+      NotificationService.error(`Error al crear el paquete`, 2200);
+      return null;
     } finally {
       setDisabledButton(false);
     }
-  }, [filesImages, params.id]);
+  }, [filesImages]);
+
+  
+  const sendEditPackages = useCallback(async (values) => {
+    setDisabledButton(true);
+    try {
+      const formData = new FormData();
+      
+      formData.append(
+        "packageData",
+        new Blob([JSON.stringify(values)], { type: "application/json" })
+      );
+      const { data: dataPackage } = await updatePackage(params.id, formData)
+      
+      NotificationService.success(`Paquete actualizado exitosamente`, 1000);
+    } catch (error) {
+      console.error(`Error al actualizar el paquete:`, error);
+      NotificationService.error(`Error al actualizar el paquete`, 2200);
+    } finally {
+      setDisabledButton(false);
+    }
+  }, [params.id]);
+
+  const sendPackages = (values) => {
+    if(params.id){
+      sendEditPackages(values)
+      return params.id
+    } else{ 
+      const newId = sendCreatePackages(values);
+      return newId
+    }
+  };
 
   const handleGuardar = async (e) => {
     e.preventDefault();
@@ -189,11 +214,16 @@ export const CreateEditPackageBasic = () => {
     }
   };
 
-  const handleSiguiente = async(e) => {
+  const handleSiguiente = async (e) => {
     e.preventDefault();
-    try { 
-      await formik.handleSubmit();
-      navigate(params.id ? `/admin/paquetes/detalles/${params.id}` : "/admin/paquetes/detalles");
+    try {
+      const values = await formik.validateForm();
+      if (Object.keys(values).length === 0) {
+        const newId = await sendPackages(formik.values);
+        if (newId) {
+          navigate(`/admin/paquetes/detalles/${newId}`);
+        }
+      }
     } catch (error) {
       console.error(error);
     }

--- a/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
@@ -26,16 +26,11 @@ import { RiEditLine, RiAddBoxLine } from 'react-icons/ri';
 
 import { GlobalContext } from "@/shared/context/GlobalContext";
 import { PackagesBreadCrumbs } from "../components/PackagesBreadCrumbs";
+import { hasChanges } from "@/shared/utils/compareObj";
 
 export const CreateEditPackageBasic = () => {
   const { state: stateContext } = useContext(GlobalContext);
   const categories = stateContext.categories;
-
-  // const location = useLocation();
-  // const {category, destination} = location.state || {};
-  
-  // console.log('category', category);
-  // console.log('destination', destination);
 
   const [disabledButton, setDisabledButton] = useState(false);
   const [filesImages, setFilesImages] = useState([]);
@@ -47,6 +42,14 @@ export const CreateEditPackageBasic = () => {
     images: [],
     bannerPhoto: { url: "" }
   });
+  const [initialValues, setInitialValues] = useState({
+    name: "",
+    active: "",
+    category: "",
+    images: [],
+    bannerPhoto: {},
+  });
+  const [formModified, setFormModified] = useState(false);
 
   const params = useParams();
   const navigate = useNavigate();
@@ -68,16 +71,21 @@ export const CreateEditPackageBasic = () => {
     category: Yup.string()
       .oneOf(categories.map(c => c.value), 'Región inválida')
       .required('La región es requerida'),
-    bannerPhoto: Yup.mixed()
-      .required('La imagen de portada es requerida')
-      .test('fileType', 'Solo se permiten archivos JPG, PNG y WebP', (value) => {
-        if (!value) return false;
-        return ['image/jpeg', 'image/png', 'image/webp'].includes(value.type);
-      })
-      .test('fileSize', 'La imagen no debe superar los 5MB', (value) => {
-        if (!value) return false;
-        return value.size <= 5 * 1024 * 1024;
-      }),
+    bannerPhoto: Yup.mixed().when([], {
+      is: () => !params.id, // Si params.id NO existe (es creación)
+      then: (schema) =>
+        schema
+          .required('La imagen de portada es requerida')
+          .test('fileType', 'Solo se permiten archivos JPG, PNG y WebP', (value) => {
+            if (!value) return false;
+            return ['image/jpeg', 'image/png', 'image/webp'].includes(value.type);
+          })
+          .test('fileSize', 'La imagen no debe superar los 5MB', (value) => {
+            if (!value) return false;
+            return value.size <= 5 * 1024 * 1024;
+          }),
+      otherwise: (schema) => schema.nullable(), // Si params.id existe (es edición), bannerPhoto puede ser null
+    }),
   });
 
   const formik = useFormik({
@@ -86,12 +94,12 @@ export const CreateEditPackageBasic = () => {
       active: "",
       category: "",
       bannerPhoto: null,
-      images: [],
     },
     validationSchema: paqueteSchema,
     onSubmit: (values) => {
-      requestPackages(values);
+      sendPackages(values);
     },
+    enableReinitialize: true,
   });
 
   // Separate function to handle fetching and updating data
@@ -109,10 +117,15 @@ export const CreateEditPackageBasic = () => {
         name: packageInfo.name || "",
         active: packageInfo.active || "",
         category: packageInfo.category.name || "",
-        bannerPhoto: null,
-        images: [],
+        bannerPhoto: {},
       });
-      
+      setInitialValues({
+        name: packageInfo.name || "",
+        active: packageInfo.active || "",
+        category: packageInfo.category.name || "",
+        // bannerPhoto: packageInfo.bannerPhoto || null,
+        // images: packageInfo.images || [],
+      });
     } catch (error) {
       console.error("Error al obtener el paquete:", error);
       NotificationService.error("Error al cargar los datos del paquete", 2200);
@@ -124,9 +137,9 @@ export const CreateEditPackageBasic = () => {
     if (params.id) {
       fetchAndUpdatePackageData(params.id);
     }
-  }, [params.id, fetchAndUpdatePackageData]);
+  }, []);
 
-  const requestPackages = useCallback(async (values) => {
+  const sendPackages = useCallback(async (values) => {
     setDisabledButton(true);
     try {
       const formData = new FormData();
@@ -152,7 +165,6 @@ export const CreateEditPackageBasic = () => {
         `Paquete ${params.id ? "actualizado" : "creado"} exitosamente`,
         1000
       );
-      navigate("/admin/paquetes");
     } catch (error) {
       console.error(
         `Error al ${params.id ? "actualizar" : "crear"} el paquete:`,
@@ -165,9 +177,29 @@ export const CreateEditPackageBasic = () => {
     } finally {
       setDisabledButton(false);
     }
-  }, [filesImages, params.id, navigate]);
+  }, [filesImages, params.id]);
 
-  // Rest of your handlers
+  const handleGuardar = async (e) => {
+    e.preventDefault();
+    try { 
+      await formik.handleSubmit();
+      navigate("/admin/paquetes");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleSiguiente = async(e) => {
+    e.preventDefault();
+    try { 
+      await formik.handleSubmit();
+      navigate(params.id ? `/admin/paquetes/detalles/${params.id}` : "/admin/paquetes/detalles");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // Rest of handlers
   const handleImageChange = (event) => {
     setFilesImages((prev) => [...prev, ...event.target.files]);
   };
@@ -186,11 +218,6 @@ export const CreateEditPackageBasic = () => {
       newImagenes.splice(index, 1);
       setFilesImages(newImagenes);
   }
-  const handleClearForm = () => {
-    formik.resetForm();
-    setFilesImages([]);
-    setImagePreview("");
-  };
 
   // Cleanup effect
   useEffect(() => {
@@ -201,7 +228,12 @@ export const CreateEditPackageBasic = () => {
     };
   }, [imagePreview]);
 
-  // In your render, replace packageValues with packageData
+  useEffect(() => {
+    // Verifica si algún campo ha cambiado comparando con los valores iniciales
+    const isModified = hasChanges(initialValues, formik.values);
+    setFormModified(isModified);
+
+  }, [formik.values]);
 
   return (
     <Container
@@ -461,7 +493,8 @@ export const CreateEditPackageBasic = () => {
           <Button
             type="button"
             variant="contained"
-            onClick={handleClearForm}
+            disabled={!formik.isValid || !formModified || disabledButton}
+            onClick={handleGuardar}
             sx={{
               backgroundColor: "#fff",
               width: {xs:'100%', md:'130px', xl:'150px'},
@@ -472,9 +505,9 @@ export const CreateEditPackageBasic = () => {
           </Button>
           <Button
             variant="contained"
-            disabled={disabledButton}
-            type="submit"
-            // onClick={() => navigate("/admin/paquetes/detalles")}
+            disabled={!formik.isValid || !formModified || disabledButton}
+            type="button"
+            onClick={handleSiguiente}
             sx={{
               backgroundColor: "#72CCA0",
               width: {xs:'100%', md:'130px', xl:'150px'},

--- a/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
@@ -17,6 +17,7 @@ import {
 import {
   createPackage,
   getPackageById,
+  postSimpleImagePackages,
   updatePackage,
 } from "@api/packageApi.js";
 import Container from "@mui/material/Container";
@@ -24,22 +25,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import { NotificationService } from "@shared/services/notistack.service.jsx";
 import { RiEditLine } from 'react-icons/ri';
 import { PackagesBreadCrumbs } from "../components/PackagesBreadCrumbs";
-
-
-const meses = [
-  "Enero",
-  "Febrero",
-  "Marzo",
-  "Abril",
-  "Mayo",
-  "Junio",
-  "Julio",
-  "Agosto",
-  "Septiembre",
-  "Octubre",
-  "Noviembre",
-  "Diciembre",
-];
 
 const niveles = [
   "Principiante",
@@ -49,10 +34,14 @@ const niveles = [
 ];
 
 const paqueteSchema = Yup.object().shape({
-  name: Yup.string().required("El nombre es requerido"),
   description: Yup.string().required("La descripción es requerida"),
-  punctuation: Yup.number().min(0).max(10),
-  all_months: Yup.array().of(Yup.number()).min(1, "Selecciona al menos un mes"),
+  itinerary: Yup.string(),
+  duration: Yup.string(),
+  physical_level: Yup.string(),
+  technical_level: Yup.string(),
+  included_services: Yup.string(),
+  // itineraryPhoto: Yup.string(),
+  // all_months: Yup.array().of(Yup.number()).min(1, "Selecciona al menos un mes"),
 });
 
 export const CreateEditPackageDetails = () => {
@@ -60,18 +49,16 @@ export const CreateEditPackageDetails = () => {
   const [imagenes, setImagenes] = useState([]);
   const [package_, setPackage] = useState(null);
   const [imagePreview, setImagePreview] = useState("");
-  const [packageValues, setPackageValues] = useState({
-    name: "",
+  const [initialValues, setInitialValues] = useState({
+  // const [packageValues, setPackageValues] = useState({
     description: "",
-    punctuation: "",
-    duration: "",
     itinerary: "",
+    duration: "",
     physical_level: "",
     technical_level: "",
     included_services: "",
-    all_months: [],
-    state: "",
-    region: "",
+    // itineraryPhoto: "",
+    // all_months: [],
   });
 
   const params = useParams();
@@ -82,29 +69,35 @@ export const CreateEditPackageDetails = () => {
       try {
         const { data: dataPackages } = await getPackageById(id);
         setPackage(dataPackages.data);
-        setPackageValues({
-          name: dataPackages.data.name,
+        formik.setValues({
           description: dataPackages.data.description,
-          punctuation: dataPackages.data.punctuation,
-          duration: dataPackages.data.duration,
           itinerary: dataPackages.data.itinerary,
+          duration: dataPackages.data.duration,
           physical_level: dataPackages.data.physical_level,
           technical_level: dataPackages.data.technical_level,
           included_services: dataPackages.data.included_services,
-          all_months: dataPackages.data.months.map((month) => month.name),
-          state: dataPackages.data.state || "Activo",
-          region: dataPackages.data.region || "Costa",
+          // itineraryPhoto: dataPackages.data.itineraryPhoto,
+          // all_months: dataPackages.data.months.map((month) => month.name),
+        });
+        setInitialValues({
+          description: dataPackages.data.description,
+          itinerary: dataPackages.data.itinerary,
+          duration: dataPackages.data.duration,
+          physical_level: dataPackages.data.physical_level,
+          technical_level: dataPackages.data.technical_level,
+          included_services: dataPackages.data.included_services,
+          // itineraryPhoto: dataPackages.data.itineraryPhoto,
+          // all_months: dataPackages.data.months.map((month) => month.name),
         });
       } catch (error) {
         console.error("Error al obtener los departures: ", error);
       }
     },
-    [setPackage, setPackageValues]
+    [setPackage, setInitialValues]
   );
 
   const requestPackages = useCallback(
     async (values) => {
-      console.log("Valores del formulario: ", values);
       setDisabledButton(true);
 
       const formData = new FormData();
@@ -112,20 +105,6 @@ export const CreateEditPackageDetails = () => {
         "packageData",
         new Blob([JSON.stringify(values)], { type: "application/json" })
       );
-      imagenes.forEach((imagen) => {
-        formData.append("filesImages", imagen, imagen.name);
-      });
-
-      if (imagenes.length === 0)
-        formData.append(
-          "filesImages",
-          new Blob([JSON.stringify([])], { type: "application/json" }),
-          "[]"
-        );
-
-      for (let [key, value] of formData.entries()) {
-        console.log(key, value);
-      }
 
       try {
         const { data: dataPackage } = params.id
@@ -162,17 +141,13 @@ export const CreateEditPackageDetails = () => {
 
   const formik = useFormik({
     initialValues: {
-      name: packageValues.name,
-      description: packageValues.description,
-      punctuation: packageValues.punctuation,
-      duration: packageValues.duration,
-      itinerary: packageValues.itinerary,
-      physical_level: packageValues.physical_level,
-      technical_level: packageValues.technical_level,
-      included_services: packageValues.included_services,
-      all_months: packageValues.all_months.map((mes) => meses.indexOf(mes)),
-      state: packageValues.state || "Activo",
-      region: packageValues.region || "",
+      description: "",
+      itinerary: "",
+      duration: "",
+      physical_level: "",
+      technical_level: "",
+      included_services: "",
+      itineraryPhoto: "",
     },
     enableReinitialize: true,
     validationSchema: paqueteSchema,
@@ -181,31 +156,52 @@ export const CreateEditPackageDetails = () => {
     },
   });
 
+  const handleGuardar = async (e) => {
+    e.preventDefault();
+    try { 
+      await formik.handleSubmit();
+      navigate("/admin/paquetes");
+    } catch (error) {
+      console.error(error);
+      NotificationService.error('Error al guardar el paquete', 2500);
+    }
+  };
+
+  const handleSiguiente = async(e) => {
+    e.preventDefault();
+    try { 
+      await formik.handleSubmit();
+      navigate(params.id ? `/admin/paquetes/destinos/${params.id}` : "/admin/paquetes/destinos");
+    } catch (error) {
+      console.error(error);
+      NotificationService.error('Error al guardar el paquete', 2500);
+    }
+  };
+
+  const postItineraryImage = useCallback( async (imgFile) => {
+    setDisabledButton(true);
+    const formData = new FormData();
+    formData.append("imageType", "itinerary");
+    formData.append("file", imgFile); // Archivo
+  
+    try {
+      // Pasar el packageId y formData
+      const response = await postSimpleImagePackages(params.id, formData); // Axios devuelve 'data' directamente
+        console.log('response', response);
+        NotificationService.success('La imagen fue cargada con éxito');
+    } catch (error) {
+        console.error(error);
+        NotificationService.error('Error al cargar la imagen');
+    } finally {
+      setDisabledButton(false);
+    }
+    }, [])
   const handleImageChange = (event) => {
-    setImagenes((prev) => [...prev, ...event.target.files]);
-  };
-
-  const handleImageTitle = (event) => {
-    const file = event.target.files[0];
-
-    if (file) {
-      const previewUrl = URL.createObjectURL(file);
-      setImagePreview(previewUrl);
-    }
-
-    if (imagenes.length > 0) {
-      const newImagenes = [...imagenes];
-      newImagenes[0] = file;
-      setImagenes(newImagenes);
-      return;
-    }
-
-    setImagenes([file]);
-  };
-
-  const handleClearForm = () => {
-    formik.resetForm();
-    setImagenes([]);
+    console.log('event', event);
+    //muestra el preview de la imagen
+    setImagenes(event.target.files);
+    //envia la imagen al backend
+    postItineraryImage(event.target.files[0]);
   };
 
   useEffect(() => {
@@ -434,7 +430,7 @@ export const CreateEditPackageDetails = () => {
                   justifyContent: 'center',
                   alignItems: 'center',
                   position: 'relative',
-                  backgroundImage: `url(${imagePreview || (package_ && package_.images.length > 0 ? package_.images[0].url : '')})`,
+                  backgroundImage: `url(${imagePreview || (package_ && package_.itineraryPhoto ? package_.itineraryPhoto.url : '')})`,
                   backgroundSize: 'cover',
                   backgroundPosition: 'center',
                   backgroundRepeat: 'no-repeat',
@@ -445,7 +441,7 @@ export const CreateEditPackageDetails = () => {
                   style={{ display: 'none' }}
                   id="raised-button-file"
                   type="file"
-                  onChange={handleImageTitle}
+                  onChange={handleImageChange}
                 />
                 <label
                   htmlFor="raised-button-file"
@@ -471,7 +467,7 @@ export const CreateEditPackageDetails = () => {
               <Button
                 type="button"
                 variant="contained"
-                onClick={handleClearForm}
+                onClick={handleGuardar}
                 sx={{
                   backgroundColor: "#fff",
                   width: "100%",
@@ -483,9 +479,8 @@ export const CreateEditPackageDetails = () => {
               <Button
                 variant="contained"
                 disabled={disabledButton}
-                // type="submit"
                 type="button"
-                onClick={() => navigate("/admin/paquetes/destinos")}
+                onClick={handleSiguiente}
                 sx={{
                   backgroundColor: "#72CCA0",
                   width: "100%",

--- a/Front/src/routes/AppRoutes.jsx
+++ b/Front/src/routes/AppRoutes.jsx
@@ -5,13 +5,13 @@ import { Suspense, lazy } from "react";
 import Layout from "../shared/pages/layout/Layout.jsx"
 import LandingPage from "../components/Home/LandingPage"
 import Loading from "../shared/components/Loading.jsx";
+
+import AdminDashboard from "../components/Dashboard/AdminDashboard";
 const Login = lazy(() => import("../components/Auth/Login"));
 const Register = lazy(() => import("../components/Auth/Register"));
 
-const UserGuestRoutes = lazy(() => import("./UserGuestRoutes.jsx"));
 import { UserAdminPrivateRoutes } from "./UserAdminPrivateRoutes.jsx";
-
-import AdminDashboard from "../components/Dashboard/AdminDashboard";
+const UserGuestRoutes = lazy(() => import("./UserGuestRoutes.jsx"));
 const Muestras = lazy(() => import("../components/muestras"));
 
 
@@ -20,7 +20,6 @@ const DepartureGrid = lazy(() => import("../modules/Departures/components/Depart
 const DepartureFull = lazy(() => import("../modules/Departures/pages/DepartureFull.jsx"));
 const Gallery = lazy(() => import("../components/PhotosGallery/Gallery.jsx"));
 import { AdminPackages } from "../modules/admin/pages/AdminPackages.jsx";
-// import { CreateEditPackage } from "../modules/admin/components/CreateEditPackage.jsx";
 import { AdminLayout } from "../modules/admin/layout/AdminLayout.jsx";
 import AdminDepartures from "../modules/admin/pages/AdminDepartures.jsx";
 import AdminComments from "../modules/admin/pages/AdminComments.jsx";
@@ -56,11 +55,10 @@ const AppRoutes = () => (
             <Route index element={<Navigate to="usuarios" replace />} />
             <Route path="usuarios" element={<AdminDashboard />} />
             <Route path="paquetes" element={<AdminPackages />} />
-            <Route path="paquetes/:id" element={<CreateEditPackageBasic />} />
-            {/* <Route path="paquetes/nuevo" element={<CreateEditPackage />} /> */}
             <Route path="paquetes/nuevo" element={<CreateEditPackageBasic />} />
-            <Route path="paquetes/detalles" element={<CreateEditPackageDetails />} />
-            <Route path="paquetes/destinos" element={<CreateEditPackageDestination />} />
+            <Route path="paquetes/basico/:id" element={<CreateEditPackageBasic />} />
+            <Route path="paquetes/detalles/:id" element={<CreateEditPackageDetails />} />
+            <Route path="paquetes/destinos/:id" element={<CreateEditPackageDestination />} />
             {/* <Route path="paquetes/:id" element={<PackageFullView />} /> */}
             {/* <Route path="paquetes/editar/:id" element={<CreateEditPackage />} /> */}
             <Route path="salidas" element={<AdminDepartures />} />

--- a/Front/src/shared/utils/compareObj.js
+++ b/Front/src/shared/utils/compareObj.js
@@ -1,0 +1,17 @@
+// src/shared/utils/compareObj.js
+
+// funcion para comparar dos objetos, devuelve true si son diferentes
+export const hasChanges = (obj1, obj2) => {
+    if (typeof obj1 !== "object" || obj1 === null) {
+      return obj1 !== obj2; // Comparación directa para valores primitivos
+    }
+  
+    if (Array.isArray(obj1)) {
+      if (!Array.isArray(obj2) || obj1.length !== obj2.length) {
+        return true; // Diferencia en tipo o longitud
+      }
+      return obj1.some((item, index) => hasChanges(item, obj2[index]));
+    }
+  
+    return Object.keys(obj1).some((key) => hasChanges(obj1[key], obj2[key]));
+  };


### PR DESCRIPTION
X Limpieza de código
--Se eliminaron console.log innecesarios en footer y DepartureCard.
--Se comentó la galería en NavBar.

X Correcciones
--CommentsCards: Se solucionó un error de types.

X Enrutado
--AppRoutes: Se agregaron parámetros a las rutas de admin-paquetes.

X Se agregó la función compareObj en utils para comparar dos objetos.

X Actualización en la API
--packageApi: Se agregaron nuevos endpoints para imágenes.

X CreateEditPackageBasic:
--En modo edición, se crea un estado inicial con datos a comparar para habilitar los botones.
--Se separaron las funciones de creación y edición de paquetes; ahora, al crear, se espera a finalizar antes de navegar con el nuevo ID.

X CreateEditPackageDetails:
--Se ajustaron los nombres de los campos.
--Se separó el proceso de agregado de imagen.