### PR TITLE
Dev emi/front/feature/admin/package details

### DIFF
--- a/Front/src/api/packageApi.js
+++ b/Front/src/api/packageApi.js
@@ -58,3 +58,12 @@ export const postImagesPackages = (packageId, formData) => {
       },
     });
   };
+
+// Actualizar una imagen de un paquete por ID.       PUT /packages/{packageId}/update-image
+export const putImagePackagesById = (packageId, formData) => {
+  return apiClient.post(`${PACKAGES_ENDPOINT}/update-image/${packageId}`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+};

--- a/Front/src/api/packageApi.js
+++ b/Front/src/api/packageApi.js
@@ -52,7 +52,7 @@ export const postSimpleImagePackages = (packageId, formData) => {
 
 // Enviar una imagen para Banner o Itinerary de un paquete.       POST /packages/{packageId}/update-image
 export const postImagesPackages = (packageId, formData) => {
-    return apiClient.post(`${PACKAGES_ENDPOINT}/${packageId}/add-image`, formData, {
+    return apiClient.post(`${PACKAGES_ENDPOINT}/${packageId}/add-images`, formData, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
@@ -61,7 +61,7 @@ export const postImagesPackages = (packageId, formData) => {
 
 // Actualizar una imagen de un paquete por ID.       PUT /packages/{packageId}/update-image
 export const putImagePackagesById = (packageId, formData) => {
-  return apiClient.post(`${PACKAGES_ENDPOINT}/update-image/${packageId}`, formData, {
+  return apiClient.put(`${PACKAGES_ENDPOINT}/update-image/${packageId}`, formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },

--- a/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
@@ -13,6 +13,7 @@ import {
   Typography,
   Paper,
   styled,
+  CircularProgress,
 } from "@mui/material";
 import {
   createPackage,
@@ -122,13 +123,13 @@ export const CreateEditPackageBasic = () => {
       // Update formik values
       formik.setValues({
         name: packageInfo.name || "",
-        active: packageInfo.active || "",
+        active: params.id ? !!packageInfo.active : null,
         category: packageInfo.category.name || "",
         bannerPhoto: {},
       });
       setInitialValues({
         name: packageInfo.name || "",
-        active: packageInfo.active || "",
+        active: params.id ? !!packageInfo.active : null,
         category: packageInfo.category.name || "",
         // bannerPhoto: packageInfo.bannerPhoto || null,
         // images: packageInfo.images || [],
@@ -193,6 +194,7 @@ export const CreateEditPackageBasic = () => {
       const { data: dataPackage } = await updatePackage(dataToSend)
       
       NotificationService.success(`Paquete actualizado exitosamente`, 1000);
+      setFormModified(false);
     } catch (error) {
       console.error(`Error al actualizar el paquete:`, error);
       NotificationService.error(`Error al actualizar el paquete`, 2200);
@@ -221,13 +223,14 @@ export const CreateEditPackageBasic = () => {
 
   const handleSiguiente = async (e, moveForward = false) => {
     e.preventDefault();
+    const selectedCategory = categories.find((c) => c.value === formik.values.category);
     try {
       const newId = await sendPackages(formik.values);
       if (moveForward) {
         if (params.id) {
-        navigate(`/admin/paquetes/detalles/${params.id}`, {state: {isNewPackage: false}});
+        navigate(`/admin/paquetes/detalles/${params.id}`, {state: {isNewPackage: {}}});
       } else {
-        navigate(`/admin/paquetes/detalles/${newId}`, {state: {isNewPackage: true}}); 
+        navigate(`/admin/paquetes/detalles/${newId}`, {state: {isNewPackage: {id: newId, categoryId: selectedCategory?.id}}}); 
       }
       }
     } catch (error) {
@@ -653,7 +656,9 @@ export const CreateEditPackageBasic = () => {
               transition: "transform 0.3s ease-in-out",
             }}
           >
-            Guardar
+            {disabledButton 
+            ? <CircularProgress size={20} color="inherit" /> 
+            : params.id ? "Guardar" : "Crear"}
           </Button>
           <Button
             variant="contained"
@@ -670,7 +675,9 @@ export const CreateEditPackageBasic = () => {
               transition: "transform 0.3s ease-in-out",
             }}
           >
-            {params.id ? "Actualizar Paquete" : "Siguiente"}
+            {disabledButton 
+            ? <CircularProgress size={20} color="inherit" /> 
+            : params.id ? "Actualizar Paquete" : "Siguiente"}
           </Button>
         </Box>
         </Box>

--- a/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
@@ -494,6 +494,28 @@ export const CreateEditPackageBasic = () => {
                   type="file"
                   onChange={handleImageChange}
                 />
+              {/* boton de nueva imagen */}
+                <label htmlFor="multiple-images-input">
+                  <Button 
+                    variant="contained"
+                    component="span"
+                    sx={{
+                      width: {xs: '100px', md: '150px', xl: '180px'},
+                      height: {xs: '100px', md: '150px', xl: '180px'},
+                      backgroundColor: '#C9C9C9',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      gap: '8px',
+                    }}
+                  >
+                    <RiAddBoxLine size={50} color= "#323232"/>
+                    <Typography sx={{ color: "#323232", fontSize: '14px', width: '50%', textAlign: 'center'}}>
+                      Agregar imágenes
+                    </Typography>
+                  </Button>
+                </label>
 
               {/* Mostrar las fotos del paquete */}
               {packageData &&
@@ -554,28 +576,6 @@ export const CreateEditPackageBasic = () => {
                   </Box>
                 )}
               )}
-              {/* boton de nueva imagen */}
-                <label htmlFor="multiple-images-input">
-                  <Button 
-                    variant="contained"
-                    component="span"
-                    sx={{
-                      width: {xs: '100px', md: '150px', xl: '180px'},
-                      height: {xs: '100px', md: '150px', xl: '180px'},
-                      backgroundColor: '#C9C9C9',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                  >
-                    <RiAddBoxLine size={50} color= "#323232"/>
-                    <Typography sx={{ color: "#323232", fontSize: '14px', width: '50%', textAlign: 'center'}}>
-                      Agregar imágenes
-                    </Typography>
-                  </Button>
-                </label>
 
               {/* Mostrar las fotos que se agregan */}
               {filesImages &&

--- a/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageBasic.jsx
@@ -204,15 +204,13 @@ export const CreateEditPackageBasic = () => {
   const sendPackages = (values) => {
     if(params.id){
       // funcion para enviar formulario de texto
-      console.log("formModified", formModified)
       if(formModified){
         if(!formik.validateForm()) return
         sendEditPackages(values)
       }
       // funcion para enviar img bannerPhoto
-      if(bannerPhoto){postBannerPhotoImage(values.bannerPhoto)}
+      if(bannerPhoto){postBannerPhotoImage(values.bannerPhoto, params.id)}
       // funcion para enviar imgs images
-      console.log("filesImages", filesImages)
       if(filesImages.length > 0){postImages(filesImages)}
       return params.id
     } else{ 
@@ -252,15 +250,14 @@ export const CreateEditPackageBasic = () => {
     }
   };
 
-  const postBannerPhotoImage = useCallback( async (imgFile) => {
+  const postBannerPhotoImage = useCallback( async (imgFile, packID) => {
     const formData = new FormData();
     formData.append("imageType", "banner");
     formData.append("file", imgFile); // Archivo
   
     try {
       // Pasar el packageId y formData
-      const response = await postSimpleImagePackages(params.id, formData); // Axios devuelve 'data' directamente
-        console.log('response', response);
+      const response = await postSimpleImagePackages(packID, formData); // Axios devuelve 'data' directamente
         NotificationService.success('La imagen fue cargada con éxito');
     } catch (error) {
         console.error(error);
@@ -279,7 +276,6 @@ export const CreateEditPackageBasic = () => {
     try {
       // Pasar el packageId y formData
       const response = await postImagesPackages(params.id, formData); // Axios devuelve 'data' directamente
-        console.log('response', response);
         NotificationService.success(isManyImgs ? `Las imágenes fueron cargadas con éxito` : `La imagen fue cargada con éxito`);
     } catch (error) {
         console.error(error);
@@ -358,6 +354,7 @@ export const CreateEditPackageBasic = () => {
                     <Typography variant="caption" color="error">
                       {formik.errors.category}
                     </Typography>
+                    
                   )}
                 </FormControl>
               </Box>
@@ -464,7 +461,10 @@ export const CreateEditPackageBasic = () => {
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
                   error={formik.touched.name && Boolean(formik.errors.name)}
-                  helperText={formik.touched.name && formik.errors.name}
+                  helperText={
+										(formik.errors.name ? formik.touched.name && formik.errors.name :
+										`${formik.values.name.length} / 55 caracteres`)
+									}
                 />
               </Box>
             </Box>

--- a/Front/src/modules/admin/pages/CreateEditPackageDestination.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDestination.jsx
@@ -1,4 +1,4 @@
-// @modules/admin/pages/CreateEditPackage.jsx
+// @modules/admin/pages/CreateEditPackageDestination.jsx
 import { useState, useCallback, useEffect } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -11,6 +11,7 @@ import {
   Paper,
   styled,
   Container,
+  CircularProgress,
 } from "@mui/material";
 import {
   getPackageById,
@@ -39,7 +40,7 @@ const paqueteSchema = Yup.object().shape({
 
 export const CreateEditPackageDestination = () => {
   const location = useLocation();
-  const isNewPackage = location.state ? location.state?.isNewPackage : false;
+  const isNewPackage = location.state ? location.state?.isNewPackage : {};
   const params = useParams();
   const navigate = useNavigate();
   
@@ -55,26 +56,35 @@ export const CreateEditPackageDestination = () => {
   const [formModified, setFormModified] = useState(false);
   const [initialValues, setInitialValues] = useState({});
 
+  // traer info del paquete
   const getPackById = useCallback(async (id) => {
     try {
       const { data: dataPackages } = await getPackageById(id);
-      console.log('dataPackages', dataPackages.data)
       setPackage(dataPackages.data);
       setPackageValues({
         locationInfo: dataPackages.data.locationInfo,
         historyInfo: dataPackages.data.historyInfo,
         activityInfo: dataPackages.data.activityInfo,
       });
-      // setInitialValues({
-      //   locationInfo: dataPackages.data.locationInfo,
-      //   historyInfo: dataPackages.data.historyInfo,
-      //   activityInfo: dataPackages.data.activityInfo,
-      // });
+      setInitialValues({
+        locationInfo: dataPackages.data.locationInfo,
+        historyInfo: dataPackages.data.historyInfo,
+        activityInfo: dataPackages.data.activityInfo,
+      });
       formik.setValues({
         locationInfo: dataPackages.data.locationInfo,
         historyInfo: dataPackages.data.historyInfo,
         activityInfo: dataPackages.data.activityInfo,
       });
+      if(dataPackages.data.destinyPhotos.length > 0){
+        dataPackages.data.destinyPhotos.map((photo, index) => {
+          setImagePreview((prevImagenes) => {
+            const newImagenes = [...prevImagenes];
+            newImagenes[index] = photo.url;
+            return newImagenes;
+          });
+        })
+      }
     } catch (error) {
       console.error("Error al obtener los departures: ", error);
     }
@@ -95,8 +105,8 @@ export const CreateEditPackageDestination = () => {
     },
   });
 
+  // guarda en el state segun posicion y muestra las imagenes
   const handleChangeImage = (event, position) => {
-    console.log('event', event);
     const file = event.target.files[0];
     if (file) {
       setImagenes((prevImagenes) => {
@@ -114,7 +124,6 @@ export const CreateEditPackageDestination = () => {
 
   const handleSiguiente = async (e, moveForward = false) => {
     e.preventDefault();
-    console.log('click')
     try {
       await sendPackages(formik.values);
       if (moveForward) {
@@ -135,15 +144,13 @@ export const CreateEditPackageDestination = () => {
         console.error('Errores de validación:', errors);
         return;
       }
-
-      // Siempre enviamos los cambios del formulario si hay package_
-      if (package_) {
+      // Actualizar el paquete si hay cambios
+      if (hasChanges(formik.values, initialValues)) {
         await sendEditPackages(values);
       }
-
       // Manejar las imágenes
-      if (package_.destinyPhotos.length === 0) {
-        if (imagenes.some(imagen => imagen !== undefined)) {
+      if (package_.destinyPhotos && Object(package_.destinyPhotos).length === 0) {
+        if (!imagenes.some(imagen => imagen === undefined)) {
           await postImages(imagenes);
         }
       } else {
@@ -156,8 +163,8 @@ export const CreateEditPackageDestination = () => {
           })
         );
       }
-
       NotificationService.success('Cambios guardados exitosamente');
+      setFormModified(false);
     } catch (error) {
       console.error('Error al guardar los cambios:', error);
       NotificationService.error('Error al guardar los cambios');
@@ -174,7 +181,7 @@ export const CreateEditPackageDestination = () => {
 
     const dataToSend = {
       id: +params.id,
-      idCategory: package_.category.id,
+			idCategory: (isNewPackage && Object.keys(isNewPackage).length !== 0) ? isNewPackage?.categoryId : package_.category.id,
       locationInfo: values.locationInfo,
       historyInfo: values.historyInfo,
       activityInfo: values.activityInfo,
@@ -199,9 +206,10 @@ export const CreateEditPackageDestination = () => {
 
   const postImages = useCallback( async (imgsFiles) => {
     const formData = new FormData();
+    formData.append("packageId", +params.id);
     formData.append("imageType", "destinyPhotos");
     imgsFiles.forEach((imagen) => {
-      formData.append("file", imagen);
+      formData.append("files", imagen);
     });
     try {
       // Pasar el packageId y formData
@@ -220,7 +228,8 @@ export const CreateEditPackageDestination = () => {
     try {
       // Pasar el packageId y formData
       const response = await putImagePackagesById(idImg, formData); // Axios devuelve 'data' directamente
-        console.log(`La imagen con Id #${idImg} fue cargada con éxito`);
+      NotificationService.success(`La imagen con Id #${idImg} fue cargada con éxito`);
+      console.log(`La imagen con Id #${idImg} fue cargada con éxito`);
     } catch (error) {
         console.error(error);
         console.log(`Error al cargar la imagen con Id #${idImg}`);
@@ -228,10 +237,8 @@ export const CreateEditPackageDestination = () => {
   }, [])
 
   useEffect(() => {
-    if (!isNewPackage) {
       getPackById(params.id);
-    }
-  }, [params.id]);
+  }, []);
 
     useEffect(() => {
       // Verifica si algún campo ha cambiado comparando con los valores iniciales
@@ -372,7 +379,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[0].url : imagePreview[0] ? imagePreview[0] : "" )})`,
+                    backgroundImage: `url(${(imagePreview[0] ? imagePreview[0] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -417,7 +424,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[1].url : imagePreview[1] ? imagePreview[1] : "" )})`,
+                    backgroundImage: `url(${(imagePreview[1] ? imagePreview[1] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -462,7 +469,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[2].url : imagePreview[2] ? imagePreview[2] : "" )})`,
+                    backgroundImage: `url(${(imagePreview[2] ? imagePreview[2] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -499,6 +506,12 @@ export const CreateEditPackageDestination = () => {
             {/* Botones */}
             <Box sx={{display:"flex", justifyContent:"space-between", gap:'1rem'}} >
               <Button
+                disabled={
+                  disabledButton ||
+                  !formik.isValid ||
+                  !formModified ||
+                  (isNewPackage && Object.keys(isNewPackage).length !== 0 && !formik.dirty)
+                }
                 type="button"
                 variant="contained"
 								onClick={(e) => handleSiguiente(e, false)}
@@ -508,13 +521,19 @@ export const CreateEditPackageDestination = () => {
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                Guardar
+                {disabledButton 
+                ? <CircularProgress size={20} color="inherit" /> 
+                : "Actualizar Paquete"}
               </Button>
               <Button
-                variant="contained"
-                disabled={disabledButton}
-                // type="submit"
+                disabled={
+                  disabledButton ||
+                  !formik.isValid ||
+                  !formModified ||
+                  (isNewPackage && Object.keys(isNewPackage).length !== 0 && !formik.dirty)
+                }
                 type="button"
+                variant="contained"
 								onClick={(e) => handleSiguiente(e, true)}
                 sx={{
                   backgroundColor: "#72CCA0",
@@ -522,7 +541,9 @@ export const CreateEditPackageDestination = () => {
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                {params.id ? "Actualizar Paquete" : "Publicar"}
+                {disabledButton 
+                ? <CircularProgress size={20} color="inherit" /> 
+                : (isNewPackage && Object.keys(isNewPackage).length === 0) ? "Actualizar Paquete" : "Publicar"}
               </Button>
             </Box>
           </Box>

--- a/Front/src/modules/admin/pages/CreateEditPackageDestination.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDestination.jsx
@@ -13,190 +13,232 @@ import {
   Container,
 } from "@mui/material";
 import {
-  createPackage,
   getPackageById,
+  postImagesPackages,
+  putImagePackagesById,
   updatePackage,
 } from "@api/packageApi.js";
 import { RiEditLine } from 'react-icons/ri';
 
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { NotificationService } from "@shared/services/notistack.service.jsx";
 import { PackagesBreadCrumbs } from "../components/PackagesBreadCrumbs";
-
-const niveles = [
-  "Principiante",
-  "Intermedio",
-  "Intermedio-Avanzado",
-  "Avanzado",
-];
+import { hasChanges } from "@/shared/utils/compareObj";
 
 const paqueteSchema = Yup.object().shape({
-  name: Yup.string().required("El nombre es requerido"),
-  description: Yup.string().required("La descripción es requerida"),
-  punctuation: Yup.number().min(0).max(10),
-  all_months: Yup.array().of(Yup.number()).min(1, "Selecciona al menos un mes"),
+  locationInfo: Yup.string()
+    .required("La información de la ubicación es requerida")
+    .max(1100, "La información de la ubicación no puede superar los 1030 caracteres"),
+  historyInfo: Yup.string()
+    .required("La información de la historia es requerida")
+    .max(1100, "La información de la historia no puede superar los 1030 caracteres"),
+  activityInfo: Yup.string()
+    .required("La información de las actividades es requerida")
+    .max(970, "La información de las actividades no puede superar los 1030 caracteres"),
 });
 
 export const CreateEditPackageDestination = () => {
-  const [disabledButton, setDisabledButton] = useState(false);
-  const [imagenes, setImagenes] = useState([]);
-  const [package_, setPackage] = useState(null);
-  const [imagePreview, setImagePreview] = useState("");
-  const [packageValues, setPackageValues] = useState({
-    name: "",
-    description: "",
-    punctuation: "",
-    duration: "",
-    itinerary: "",
-    physical_level: "",
-    technical_level: "",
-    included_services: "",
-    all_months: [],
-    state: "",
-    region: "",
-  });
-
+  const location = useLocation();
+  const isNewPackage = location.state ? location.state?.isNewPackage : false;
   const params = useParams();
   const navigate = useNavigate();
+  
+  const [disabledButton, setDisabledButton] = useState(false);
+  const [imagenes, setImagenes] = useState([...new Array(3)]);
+  const [imagePreview, setImagePreview] = useState([...new Array(3)]);
+  const [package_, setPackage] = useState(null);
+  const [packageValues, setPackageValues] = useState({
+    locationInfo: "",
+    historyInfo: "",
+    activityInfo: "",
+  });
+  const [formModified, setFormModified] = useState(false);
+  const [initialValues, setInitialValues] = useState({});
 
-  const getPackById = useCallback(
-    async (id) => {
-      try {
-        const { data: dataPackages } = await getPackageById(id);
-        setPackage(dataPackages.data);
-        setPackageValues({
-          name: dataPackages.data.name,
-          description: dataPackages.data.description,
-          punctuation: dataPackages.data.punctuation,
-          duration: dataPackages.data.duration,
-          itinerary: dataPackages.data.itinerary,
-          physical_level: dataPackages.data.physical_level,
-          technical_level: dataPackages.data.technical_level,
-          included_services: dataPackages.data.included_services,
-          all_months: dataPackages.data.months.map((month) => month.name),
-          state: dataPackages.data.state || "Activo",
-          region: dataPackages.data.region || "Costa",
-        });
-      } catch (error) {
-        console.error("Error al obtener los departures: ", error);
-      }
-    },
-    [setPackage, setPackageValues]
-  );
-
-  const requestPackages = useCallback(
-    async (values) => {
-      console.log("Valores del formulario: ", values);
-      setDisabledButton(true);
-
-      const formData = new FormData();
-      formData.append(
-        "packageData",
-        new Blob([JSON.stringify(values)], { type: "application/json" })
-      );
-      imagenes.forEach((imagen) => {
-        formData.append("filesImages", imagen, imagen.name);
+  const getPackById = useCallback(async (id) => {
+    try {
+      const { data: dataPackages } = await getPackageById(id);
+      console.log('dataPackages', dataPackages.data)
+      setPackage(dataPackages.data);
+      setPackageValues({
+        locationInfo: dataPackages.data.locationInfo,
+        historyInfo: dataPackages.data.historyInfo,
+        activityInfo: dataPackages.data.activityInfo,
       });
-
-      if (imagenes.length === 0)
-        formData.append(
-          "filesImages",
-          new Blob([JSON.stringify([])], { type: "application/json" }),
-          "[]"
-        );
-
-      for (let [key, value] of formData.entries()) {
-        console.log(key, value);
-      }
-
-      try {
-        const { data: dataPackage } = params.id
-          ? await updatePackage(formData)
-          : await createPackage(formData);
-
-        console.log("Respuesta del backend: ", dataPackage);
-        NotificationService.success(
-          params.id
-            ? "Paquete actualizado exitosamente"
-            : "Paquete creado exitosamente",
-          1000
-        );
-        navigate("/admin/paquetes");
-      } catch (error) {
-        console.error(
-          params.id
-            ? "Error al actualizar el paquete"
-            : "Error al crear el paquete",
-          error.response
-        );
-        NotificationService.error(
-          params.id
-            ? "Error al actualizar el paquete"
-            : "Error al crear el paquete",
-          2200
-        );
-      } finally {
-        setDisabledButton(false);
-      }
-    },
-    [imagenes]
-  );
+      // setInitialValues({
+      //   locationInfo: dataPackages.data.locationInfo,
+      //   historyInfo: dataPackages.data.historyInfo,
+      //   activityInfo: dataPackages.data.activityInfo,
+      // });
+      formik.setValues({
+        locationInfo: dataPackages.data.locationInfo,
+        historyInfo: dataPackages.data.historyInfo,
+        activityInfo: dataPackages.data.activityInfo,
+      });
+    } catch (error) {
+      console.error("Error al obtener los departures: ", error);
+    }
+  },
+  [setPackage, setPackageValues]
+);
 
   const formik = useFormik({
     initialValues: {
-      name: packageValues.name,
-      description: packageValues.description,
-      punctuation: packageValues.punctuation,
-      duration: packageValues.duration,
-      itinerary: packageValues.itinerary,
-      physical_level: packageValues.physical_level,
-      technical_level: packageValues.technical_level,
-      included_services: packageValues.included_services,
-      state: packageValues.state || "Activo",
-      region: packageValues.region || "",
+      locationInfo: "",
+      historyInfo: "",
+      activityInfo: "",
     },
     enableReinitialize: true,
     validationSchema: paqueteSchema,
     onSubmit: (values) => {
-      requestPackages(values);
+      sendPackages(values);
     },
   });
 
-  const handleImageTitle = (event) => {
+  const handleChangeImage = (event, position) => {
+    console.log('event', event);
     const file = event.target.files[0];
-
     if (file) {
-      const previewUrl = URL.createObjectURL(file);
-      setImagePreview(previewUrl);
+      setImagenes((prevImagenes) => {
+        const newImagenes = [...prevImagenes];
+        newImagenes[position] = file;
+        return newImagenes;
+      });
+      setImagePreview((prevImags) => {
+        const newImags = [...prevImags];
+        newImags[position] = URL.createObjectURL(file);
+        return newImags;
+      });
     }
+  };
 
-    if (imagenes.length > 0) {
-      const newImagenes = [...imagenes];
-      newImagenes[0] = file;
-      setImagenes(newImagenes);
+  const handleSiguiente = async (e, moveForward = false) => {
+    e.preventDefault();
+    console.log('click')
+    try {
+      await sendPackages(formik.values);
+      if (moveForward) {
+					navigate(`/admin/paquetes/`); 
+				}
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const sendPackages = async (values) => {
+    try {
+      setDisabledButton(true);
+      
+      // Validar el formulario
+      const errors = await formik.validateForm();
+      if (Object.keys(errors).length > 0) {
+        console.error('Errores de validación:', errors);
+        return;
+      }
+
+      // Siempre enviamos los cambios del formulario si hay package_
+      if (package_) {
+        await sendEditPackages(values);
+      }
+
+      // Manejar las imágenes
+      if (package_.destinyPhotos.length === 0) {
+        if (imagenes.some(imagen => imagen !== undefined)) {
+          await postImages(imagenes);
+        }
+      } else {
+        await Promise.all(
+          imagenes.map((imagen, index) => {
+            if (imagen !== undefined && package_?.destinyPhotos[index]?.id) {
+              return putImageById(package_.destinyPhotos[index].id, imagen);
+            }
+            return Promise.resolve();
+          })
+        );
+      }
+
+      NotificationService.success('Cambios guardados exitosamente');
+    } catch (error) {
+      console.error('Error al guardar los cambios:', error);
+      NotificationService.error('Error al guardar los cambios');
+    } finally {
+      setDisabledButton(false);
+    }
+  };
+
+  const sendEditPackages = async (values) => {
+    if (!package_?.category?.id) {
+      console.error('No se encontró la categoría del paquete');
       return;
     }
 
-    setImagenes([file]);
+    const dataToSend = {
+      id: +params.id,
+      idCategory: package_.category.id,
+      locationInfo: values.locationInfo,
+      historyInfo: values.historyInfo,
+      activityInfo: values.activityInfo,
+    };
+
+    try {
+      const { data: dataPackage } = await updatePackage(dataToSend);
+      
+      // Actualizar los valores iniciales después de una actualización exitosa
+      setInitialValues({
+        locationInfo: values.locationInfo,
+        historyInfo: values.historyInfo,
+        activityInfo: values.activityInfo,
+      });
+      
+      return dataPackage;
+    } catch (error) {
+      console.error('Error al actualizar el paquete:', error);
+      throw error; // Propagar el error para manejarlo en sendPackages
+    }
   };
 
-  const handleClearForm = () => {
-    formik.resetForm();
-    setImagenes([]);
-  };
+  const postImages = useCallback( async (imgsFiles) => {
+    const formData = new FormData();
+    formData.append("imageType", "destinyPhotos");
+    imgsFiles.forEach((imagen) => {
+      formData.append("file", imagen);
+    });
+    try {
+      // Pasar el packageId y formData
+      const response = await postImagesPackages(params.id, formData); // Axios devuelve 'data' directamente
+        NotificationService.success(`Las imágenes fueron cargadas con éxito`);
+    } catch (error) {
+        console.error(error);
+        NotificationService.error('Error al cargar las imágenes');
+    }
+  }, [])
+
+  const putImageById = useCallback( async (idImg, imgFile) => {
+    const formData = new FormData();
+    formData.append("imageId", idImg);
+    formData.append("image", imgFile); // Archivo
+    try {
+      // Pasar el packageId y formData
+      const response = await putImagePackagesById(idImg, formData); // Axios devuelve 'data' directamente
+        console.log(`La imagen con Id #${idImg} fue cargada con éxito`);
+    } catch (error) {
+        console.error(error);
+        console.log(`Error al cargar la imagen con Id #${idImg}`);
+    }
+  }, [])
 
   useEffect(() => {
-    if (params.id) {
+    if (!isNewPackage) {
       getPackById(params.id);
     }
-  }, [params.id, getPackById]);
+  }, [params.id]);
 
-  useEffect(() => {
-    if (imagenes.length > 0) {
-      const previewUrl = URL.createObjectURL(imagenes[0]);
-      setImagePreview(previewUrl);
-    }
-  }, [imagenes]);
+    useEffect(() => {
+      // Verifica si algún campo ha cambiado comparando con los valores iniciales
+      const isModified = hasChanges(formik.values, initialValues);
+      setFormModified(isModified);
+      if(imagenes.some(imagen => imagen !== undefined)) setFormModified(true);
+    }, [formik.values, imagenes]);
 
   return (
     <Container
@@ -235,21 +277,22 @@ export const CreateEditPackageDestination = () => {
                   </Typography>
                   <TextField
                     fullWidth
-                    id="description"
-                    name="description"
+                    id="locationInfo"
+                    name="locationInfo"
                     label="Descripción de donde se encuentra"
                     multiline
                     rows={5}
-                    value={formik.values.description}
+                    value={formik.values.locationInfo}
                     onChange={formik.handleChange}
                     onBlur={formik.handleBlur}
                     error={
-                      formik.touched.description &&
-                      Boolean(formik.errors.description)
+                      formik.touched.locationInfo &&
+                      Boolean(formik.errors.locationInfo)
                     }
                     helperText={
-                      formik.touched.description && formik.errors.description
-                    }
+											(formik.errors.locationInfo ? formik.touched.locationInfo && formik.errors.locationInfo :
+											`${formik.values.locationInfo.length} / 1100 caracteres`)
+										}
                   />
                 </Paper>
                 <Paper
@@ -264,21 +307,22 @@ export const CreateEditPackageDestination = () => {
                   </Typography>
                   <TextField
                     fullWidth
-                    id="itinerary"
-                    name="itinerary"
+                    id="historyInfo"
+                    name="historyInfo"
                     label="Su historia y lo que lo hace atractivo"
                     multiline
                     rows={5}
-                    value={formik.values.itinerary}
+                    value={formik.values.historyInfo}
                     onChange={formik.handleChange}
                     onBlur={formik.handleBlur}
                     error={
-                      formik.touched.itinerary &&
-                      Boolean(formik.errors.itinerary)
+                      formik.touched.historyInfo &&
+                      Boolean(formik.errors.historyInfo)
                     }
                     helperText={
-                      formik.touched.itinerary && formik.errors.itinerary
-                    }
+											(formik.errors.historyInfo ? formik.touched.historyInfo && formik.errors.historyInfo :
+											`${formik.values.historyInfo.length} / 1100 caracteres`)
+										}
                   />
                 </Paper>
                 <Paper
@@ -293,21 +337,22 @@ export const CreateEditPackageDestination = () => {
                   </Typography>
                   <TextField
                     fullWidth
-                    id="itinerary"
-                    name="itinerary"
+                    id="activityInfo"
+                    name="activityInfo"
                     label="Cómo es la propuesta de excursión"
                     multiline
                     rows={5}
-                    value={formik.values.itinerary}
+                    value={formik.values.activityInfo}
                     onChange={formik.handleChange}
                     onBlur={formik.handleBlur}
                     error={
-                      formik.touched.itinerary &&
-                      Boolean(formik.errors.itinerary)
+                      formik.touched.activityInfo &&
+                      Boolean(formik.errors.activityInfo)
                     }
                     helperText={
-                      formik.touched.itinerary && formik.errors.itinerary
-                    }
+											(formik.errors.activityInfo ? formik.touched.activityInfo && formik.errors.activityInfo :
+											`${formik.values.activityInfo.length} / 970 caracteres`)
+										}
                   />
                 </Paper>
               </Box>
@@ -327,7 +372,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${imagePreview || (package_ && package_.images.length > 0 ? package_.images[0].url : '')})`,
+                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[0].url : imagePreview[0] ? imagePreview[0] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -336,12 +381,12 @@ export const CreateEditPackageDestination = () => {
                   <input
                     accept="image/*"
                     style={{ display: 'none' }}
-                    id="raised-button-file"
+                    id="raised-button-file1"
                     type="file"
-                    onChange={handleImageTitle}
+                    onChange={(e) => handleChangeImage(e, 0)}
                   />
                   <label
-                    htmlFor="raised-button-file"
+                    htmlFor="raised-button-file1"
                     style={{ position: 'absolute', left: 20, top: 20 }}
                   >
                     <Button
@@ -372,7 +417,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${imagePreview || (package_ && package_.images.length > 0 ? package_.images[0].url : '')})`,
+                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[1].url : imagePreview[1] ? imagePreview[1] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -381,12 +426,12 @@ export const CreateEditPackageDestination = () => {
                   <input
                     accept="image/*"
                     style={{ display: 'none' }}
-                    id="raised-button-file"
+                    id="raised-button-file2"
                     type="file"
-                    onChange={handleImageTitle}
+                    onChange={(e) => handleChangeImage(e, 1)}
                   />
                   <label
-                    htmlFor="raised-button-file"
+                    htmlFor="raised-button-file2"
                     style={{ position: 'absolute', left: 20, top: 20 }}
                   >
                     <Button
@@ -417,7 +462,7 @@ export const CreateEditPackageDestination = () => {
                     justifyContent: 'center',
                     alignItems: 'center',
                     position: 'relative',
-                    backgroundImage: `url(${imagePreview || (package_ && package_.images.length > 0 ? package_.images[0].url : '')})`,
+                    backgroundImage: `url(${(package_ && package_.destinyPhotos.length > 0 ? package_.destinyPhotos[2].url : imagePreview[2] ? imagePreview[2] : "" )})`,
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
                     backgroundRepeat: 'no-repeat',
@@ -426,12 +471,12 @@ export const CreateEditPackageDestination = () => {
                   <input
                     accept="image/*"
                     style={{ display: 'none' }}
-                    id="raised-button-file"
+                    id="raised-button-file3"
                     type="file"
-                    onChange={handleImageTitle}
+                    onChange={(e) => handleChangeImage(e, 2)}
                   />
                   <label
-                    htmlFor="raised-button-file"
+                    htmlFor="raised-button-file3"
                     style={{ position: 'absolute', left: 20, top: 20 }}
                   >
                     <Button
@@ -456,7 +501,7 @@ export const CreateEditPackageDestination = () => {
               <Button
                 type="button"
                 variant="contained"
-                onClick={handleClearForm}
+								onClick={(e) => handleSiguiente(e, false)}
                 sx={{
                   backgroundColor: "#fff",
                   width: "100%",
@@ -470,7 +515,7 @@ export const CreateEditPackageDestination = () => {
                 disabled={disabledButton}
                 // type="submit"
                 type="button"
-                onClick={() => navigate("/admin/paquetes/destinos")}
+								onClick={(e) => handleSiguiente(e, true)}
                 sx={{
                   backgroundColor: "#72CCA0",
                   width: "100%",
@@ -480,7 +525,6 @@ export const CreateEditPackageDestination = () => {
                 {params.id ? "Actualizar Paquete" : "Publicar"}
               </Button>
             </Box>
-
           </Box>
         </Box>
       </Box>

--- a/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
@@ -39,57 +39,45 @@ export const CreateEditPackageDetails = () => {
   const location = useLocation();
   const isNewPackage = location.state ? location.state?.isNewPackage : false;
 	
-	const paqueteSchema = () =>
-		Yup.object().shape({
-			description: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => 
-					schema
-						.required("La descripción es requerida")
-						.max(1030, "La descripción no puede superar los 255 caracteres"),
-				otherwise: (schema) => 
-					schema.max(1030, "La descripción no puede superar los 255 caracteres"),
-			}),
-			itinerary: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => 
-					schema
-						.required("El itinerario es requerido")
-						.max(10000, "El itinerario no puede superar los 255 caracteres"),
-				otherwise: (schema) => 
-					schema.max(10000, "El i	tinerario no puede superar los 255 caracteres"),
-			}),
-			duration: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => schema.required("La duración es requerida"),
-			}),
-			physical_level: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => schema.required("El nivel físico es requerido"),
-			}),
-			technical_level: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => schema.required("El nivel técnico es requerido"),
-			}),
-			included_services: Yup.string().when([], {
-				is: isNewPackage,
-				then: (schema) => 
-					schema
-						.required("Los servicios incluidos son requeridos")
-						.max(320, "Los servicios incluidos no pueden superar los 255 caracteres"),
-				otherwise: (schema) => 
-					schema.max(320, "Los servicios incluidos no pueden superar los 255 caracteres"),
-			}),
-			itineraryImg: Yup.mixed().when([], {
-				is: isNewPackage,
-				then: (schema) => schema.required("La imagen del itinerario es requerida"),
-				otherwise: (schema) => schema.notRequired(),
-			})
-		});
+  const paqueteSchema = () =>
+    Yup.object().shape({
+      description: Yup.string()
+        .required("La descripción es requerida")
+        .max(1030, "La descripción no puede superar los 1030 caracteres"),
+  
+      itinerary: Yup.string()
+        .required("El itinerario es requerido")
+        .max(10000, "El itinerario no puede superar los 10000 caracteres"),
+  
+      duration: Yup.string().required("La duración es requerida"),
+  
+      physical_level: Yup.string().required("El nivel físico es requerido"),
+  
+      technical_level: Yup.string().required("El nivel técnico es requerido"),
+  
+      included_services: Yup.string()
+        .required("Los servicios incluidos son requeridos")
+        .max(320, "Los servicios incluidos no pueden superar los 320 caracteres"),
+      itineraryPhoto: Yup.mixed().when([], {
+        is: () => isNewPackage, // Si params.id NO existe (es creación)
+        then: (schema) =>
+          schema
+            .required('La imagen de itinerario es requerida')
+            .test('fileType', 'Solo se permiten archivos JPG, PNG y WebP', (value) => {
+              if (!value) return false;
+              return ['image/jpeg', 'image/png', 'image/webp'].includes(value.type);
+            })
+            .test('fileSize', 'La imagen no debe superar los 5MB', (value) => {
+              if (!value) return false;
+              return value.size <= 5 * 1024 * 1024;
+            }),
+        otherwise: (schema) => schema.nullable(), 
+      }),
+    });
 	
 
   const [disabledButton, setDisabledButton] = useState(false);
-  const [itineraryImg, setItineraryImg] = useState(null);
+  const [itineraryPhoto, setItineraryPhoto] = useState(null);
   const [package_, setPackage] = useState(null);
   const [imagePreview, setImagePreview] = useState("");
   const [initialValues, setInitialValues] = useState({});
@@ -158,8 +146,8 @@ export const CreateEditPackageDetails = () => {
         if(!formik.validateForm()) return
         sendEditPackages(values)
       }
-      // funcion para enviar img itineraryImg
-      if(itineraryImg){postItineraryImage(itineraryImg)}
+      // funcion para enviar img itineraryPhoto
+      if(itineraryPhoto){postItineraryImage(itineraryPhoto, params.id)}
 
 			setDisabledButton(false);
   };
@@ -179,6 +167,17 @@ export const CreateEditPackageDetails = () => {
     try {
       const { data: dataPackage } = await updatePackage(dataToSend)
       NotificationService.success(`Paquete actualizado exitosamente`, 1000);
+      setInitialValues({
+        id: +params.id,
+        idCategory: values.idCategory,
+        description: values.description,
+        itinerary: values.itinerary,
+        duration: values.duration,
+        physical_level: values.physical_level,
+        technical_level: values.technical_level,
+        included_services: values.included_services,
+        itineraryPhoto: values.itineraryPhoto,
+      });
     } catch (error) {
       console.error(`Error al actualizar el paquete:`, error);
       NotificationService.error(`Error al actualizar el paquete`, 2200);
@@ -201,14 +200,14 @@ export const CreateEditPackageDetails = () => {
     }
   };
 
-  const postItineraryImage = useCallback( async (imgFile) => {
+  const postItineraryImage = useCallback( async (imgFile, packID) => {
     const formData = new FormData();
     formData.append("imageType", "itinerary");
     formData.append("file", imgFile); // Archivo
   
     try {
       // Pasar el packageId y formData
-      const response = await postSimpleImagePackages(params.id, formData); // Axios devuelve 'data' directamente
+      const response = await postSimpleImagePackages(packID, formData); // Axios devuelve 'data' directamente
         console.log('response', response);
         NotificationService.success('La imagen fue cargada con éxito');
     } catch (error) {
@@ -218,10 +217,9 @@ export const CreateEditPackageDetails = () => {
   }, [])
 
   const handleImageChange = (event) => {
-    //cambia la imagen para que el useEffect muestre el preview de la imagen
-    setItineraryImg(event.target.files);
-    //envia la imagen al backend
-    formik.setValues({itineraryPhoto: event.target.files[0]});
+    const file = event.target.files[0];
+    setItineraryPhoto(file);
+    formik.setFieldValue("itineraryPhoto", file);
   };
 
   useEffect(() => {
@@ -231,25 +229,17 @@ export const CreateEditPackageDetails = () => {
   }, [params.id, getPackById]);
 
   useEffect(() => {
-    if (itineraryImg && itineraryImg.length > 0) {
-      const previewUrl = URL.createObjectURL(itineraryImg[0]);
-      setImagePreview(previewUrl);
+    if (itineraryPhoto) {
+        const previewUrl = URL.createObjectURL(itineraryPhoto);
+        setImagePreview(previewUrl);
     }
-  }, [itineraryImg]);
+  }, [itineraryPhoto]);
 
   useEffect(() => {
     // Verifica si algún campo ha cambiado comparando con los valores iniciales
     const isModified = hasChanges(initialValues, formik.values);
     setFormModified(isModified);
-		if (itineraryImg) setFormModified(true);
-		console.log('disabledButton', disabledButton);
-		console.log('!formik.isValid', !formik.isValid);
-		console.log('formik.errors', formik.errors);
-    console.log('isNewPackage', isNewPackage);
-		console.log('!formik.dirty', !formik.dirty);
-		console.log('itineraryImg', itineraryImg);
-
-
+		if (itineraryPhoto) setFormModified(true);
   }, [formik.values]);
 
   return (
@@ -265,12 +255,8 @@ export const CreateEditPackageDetails = () => {
         sx={{ mt: 2 }}
       >
         {/*Box container principal*/}
-        <Box 
-          sx={{display: 'flex', gap: '1rem'}}
-        >
-
+        <Box sx={{display: 'flex', gap: '1rem'}}>
           <Box sx={{flex:2}}>
-
               {/*IZQ: De que se trata e itinerario*/}
               <Box
                 sx={{ display: "flex", flexDirection: "column", gap: 2 }}

--- a/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
@@ -15,16 +15,16 @@ import {
   styled,
 } from "@mui/material";
 import {
-  createPackage,
   getPackageById,
   postSimpleImagePackages,
   updatePackage,
 } from "@api/packageApi.js";
 import Container from "@mui/material/Container";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { NotificationService } from "@shared/services/notistack.service.jsx";
 import { RiEditLine } from 'react-icons/ri';
 import { PackagesBreadCrumbs } from "../components/PackagesBreadCrumbs";
+import { hasChanges } from "@/shared/utils/compareObj";
 
 const niveles = [
   "Principiante",
@@ -33,61 +33,96 @@ const niveles = [
   "Avanzado",
 ];
 
-const paqueteSchema = Yup.object().shape({
-  description: Yup.string().required("La descripción es requerida"),
-  itinerary: Yup.string(),
-  duration: Yup.string(),
-  physical_level: Yup.string(),
-  technical_level: Yup.string(),
-  included_services: Yup.string(),
-  // itineraryPhoto: Yup.string(),
-  // all_months: Yup.array().of(Yup.number()).min(1, "Selecciona al menos un mes"),
-});
-
 export const CreateEditPackageDetails = () => {
+	const params = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isNewPackage = location.state ? location.state?.isNewPackage : false;
+	
+	const paqueteSchema = () =>
+		Yup.object().shape({
+			description: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => 
+					schema
+						.required("La descripción es requerida")
+						.max(1030, "La descripción no puede superar los 255 caracteres"),
+				otherwise: (schema) => 
+					schema.max(1030, "La descripción no puede superar los 255 caracteres"),
+			}),
+			itinerary: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => 
+					schema
+						.required("El itinerario es requerido")
+						.max(10000, "El itinerario no puede superar los 255 caracteres"),
+				otherwise: (schema) => 
+					schema.max(10000, "El i	tinerario no puede superar los 255 caracteres"),
+			}),
+			duration: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => schema.required("La duración es requerida"),
+			}),
+			physical_level: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => schema.required("El nivel físico es requerido"),
+			}),
+			technical_level: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => schema.required("El nivel técnico es requerido"),
+			}),
+			included_services: Yup.string().when([], {
+				is: isNewPackage,
+				then: (schema) => 
+					schema
+						.required("Los servicios incluidos son requeridos")
+						.max(320, "Los servicios incluidos no pueden superar los 255 caracteres"),
+				otherwise: (schema) => 
+					schema.max(320, "Los servicios incluidos no pueden superar los 255 caracteres"),
+			}),
+			itineraryImg: Yup.mixed().when([], {
+				is: isNewPackage,
+				then: (schema) => schema.required("La imagen del itinerario es requerida"),
+				otherwise: (schema) => schema.notRequired(),
+			})
+		});
+	
+
   const [disabledButton, setDisabledButton] = useState(false);
-  const [imagenes, setImagenes] = useState([]);
+  const [itineraryImg, setItineraryImg] = useState(null);
   const [package_, setPackage] = useState(null);
   const [imagePreview, setImagePreview] = useState("");
-  const [initialValues, setInitialValues] = useState({
-  // const [packageValues, setPackageValues] = useState({
-    description: "",
-    itinerary: "",
-    duration: "",
-    physical_level: "",
-    technical_level: "",
-    included_services: "",
-    // itineraryPhoto: "",
-    // all_months: [],
-  });
-
-  const params = useParams();
-  const navigate = useNavigate();
+  const [initialValues, setInitialValues] = useState({});
+  const [formModified, setFormModified] = useState(false);
 
   const getPackById = useCallback(
-    async (id) => {
+		async (id) => {
+			if(isNewPackage) return;
       try {
         const { data: dataPackages } = await getPackageById(id);
         setPackage(dataPackages.data);
+				console.log('dataPackages.data', dataPackages.data);
         formik.setValues({
+					id: +params.id,
+					idCategory: dataPackages.data.category.id,
           description: dataPackages.data.description,
           itinerary: dataPackages.data.itinerary,
           duration: dataPackages.data.duration,
           physical_level: dataPackages.data.physical_level,
           technical_level: dataPackages.data.technical_level,
           included_services: dataPackages.data.included_services,
-          // itineraryPhoto: dataPackages.data.itineraryPhoto,
-          // all_months: dataPackages.data.months.map((month) => month.name),
+					itineraryPhoto: {},
         });
         setInitialValues({
+					id: +params.id,
+					idCategory: dataPackages.data.category.id,
           description: dataPackages.data.description,
           itinerary: dataPackages.data.itinerary,
           duration: dataPackages.data.duration,
           physical_level: dataPackages.data.physical_level,
           technical_level: dataPackages.data.technical_level,
           included_services: dataPackages.data.included_services,
-          // itineraryPhoto: dataPackages.data.itineraryPhoto,
-          // all_months: dataPackages.data.months.map((month) => month.name),
+					itineraryPhoto: {},
         });
       } catch (error) {
         console.error("Error al obtener los departures: ", error);
@@ -96,90 +131,77 @@ export const CreateEditPackageDetails = () => {
     [setPackage, setInitialValues]
   );
 
-  const requestPackages = useCallback(
-    async (values) => {
-      setDisabledButton(true);
-
-      const formData = new FormData();
-      formData.append(
-        "packageData",
-        new Blob([JSON.stringify(values)], { type: "application/json" })
-      );
-
-      try {
-        const { data: dataPackage } = params.id
-          ? await updatePackage(formData)
-          : await createPackage(formData);
-
-        console.log("Respuesta del backend: ", dataPackage);
-        NotificationService.success(
-          params.id
-            ? "Paquete actualizado exitosamente"
-            : "Paquete creado exitosamente",
-          1000
-        );
-        navigate("/admin/paquetes");
-      } catch (error) {
-        console.error(
-          params.id
-            ? "Error al actualizar el paquete"
-            : "Error al crear el paquete",
-          error.response
-        );
-        NotificationService.error(
-          params.id
-            ? "Error al actualizar el paquete"
-            : "Error al crear el paquete",
-          2200
-        );
-      } finally {
-        setDisabledButton(false);
-      }
-    },
-    [imagenes]
-  );
-
   const formik = useFormik({
     initialValues: {
+			id: "",
+			idCategory: "",
       description: "",
       itinerary: "",
       duration: "",
       physical_level: "",
       technical_level: "",
       included_services: "",
-      itineraryPhoto: "",
+      itineraryPhoto: {},
     },
     enableReinitialize: true,
     validationSchema: paqueteSchema,
     onSubmit: (values) => {
-      requestPackages(values);
+      sendPackages(values);
     },
   });
 
-  const handleGuardar = async (e) => {
-    e.preventDefault();
-    try { 
-      await formik.handleSubmit();
-      navigate("/admin/paquetes");
-    } catch (error) {
-      console.error(error);
-      NotificationService.error('Error al guardar el paquete', 2500);
-    }
+	const sendPackages = (values) => {
+      // funcion para enviar formulario de texto
+			setDisabledButton(true);
+      console.log("formModified", formModified)
+      if(formModified){
+        if(!formik.validateForm()) return
+        sendEditPackages(values)
+      }
+      // funcion para enviar img itineraryImg
+      if(itineraryImg){postItineraryImage(itineraryImg)}
+
+			setDisabledButton(false);
   };
 
-  const handleSiguiente = async(e) => {
+	const sendEditPackages = useCallback(async (values) => {
+		console.log('formik.values', formik.values);
+		const dataToSend = {
+			id: +params.id,
+			idCategory: values.idCategory,
+			description: values.description,
+			itinerary: values.itinerary,
+			duration: values.duration,
+			physical_level: values.physical_level,
+			technical_level: values.technical_level,
+			included_services: values.included_services,
+		}
+    try {
+      const { data: dataPackage } = await updatePackage(dataToSend)
+      NotificationService.success(`Paquete actualizado exitosamente`, 1000);
+    } catch (error) {
+      console.error(`Error al actualizar el paquete:`, error);
+      NotificationService.error(`Error al actualizar el paquete`, 2200);
+    }
+  }, [params.id]);
+
+	const handleSiguiente = async (e, moveForward = false) => {
     e.preventDefault();
-    try { 
-      await formik.handleSubmit();
-      navigate(params.id ? `/admin/paquetes/destinos/${params.id}` : "/admin/paquetes/destinos");
+    try {
+      await sendPackages(formik.values);
+      if (moveForward) {
+        if (!isNewPackage) {
+					navigate(params.id && `/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: false}});
+				} else {
+					navigate(`/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: true}}); 
+				}
+      }
     } catch (error) {
       console.error(error);
-      NotificationService.error('Error al guardar el paquete', 2500);
     }
   };
 
   const postItineraryImage = useCallback( async (imgFile) => {
-    setDisabledButton(true);
     const formData = new FormData();
     formData.append("imageType", "itinerary");
     formData.append("file", imgFile); // Archivo
@@ -192,16 +214,14 @@ export const CreateEditPackageDetails = () => {
     } catch (error) {
         console.error(error);
         NotificationService.error('Error al cargar la imagen');
-    } finally {
-      setDisabledButton(false);
-    }
-    }, [])
+		}
+  }, [])
+
   const handleImageChange = (event) => {
-    console.log('event', event);
-    //muestra el preview de la imagen
-    setImagenes(event.target.files);
+    //cambia la imagen para que el useEffect muestre el preview de la imagen
+    setItineraryImg(event.target.files);
     //envia la imagen al backend
-    postItineraryImage(event.target.files[0]);
+    formik.setValues({itineraryPhoto: event.target.files[0]});
   };
 
   useEffect(() => {
@@ -211,11 +231,26 @@ export const CreateEditPackageDetails = () => {
   }, [params.id, getPackById]);
 
   useEffect(() => {
-    if (imagenes.length > 0) {
-      const previewUrl = URL.createObjectURL(imagenes[0]);
+    if (itineraryImg && itineraryImg.length > 0) {
+      const previewUrl = URL.createObjectURL(itineraryImg[0]);
       setImagePreview(previewUrl);
     }
-  }, [imagenes]);
+  }, [itineraryImg]);
+
+  useEffect(() => {
+    // Verifica si algún campo ha cambiado comparando con los valores iniciales
+    const isModified = hasChanges(initialValues, formik.values);
+    setFormModified(isModified);
+		if (itineraryImg) setFormModified(true);
+		console.log('disabledButton', disabledButton);
+		console.log('!formik.isValid', !formik.isValid);
+		console.log('formik.errors', formik.errors);
+    console.log('isNewPackage', isNewPackage);
+		console.log('!formik.dirty', !formik.dirty);
+		console.log('itineraryImg', itineraryImg);
+
+
+  }, [formik.values]);
 
   return (
     <Container
@@ -239,8 +274,6 @@ export const CreateEditPackageDetails = () => {
               {/*IZQ: De que se trata e itinerario*/}
               <Box
                 sx={{ display: "flex", flexDirection: "column", gap: 2 }}
-                item
-                xs={8}
               >
                 <Paper
                   elevation={3}
@@ -266,9 +299,10 @@ export const CreateEditPackageDetails = () => {
                       formik.touched.description &&
                       Boolean(formik.errors.description)
                     }
-                    helperText={
-                      formik.touched.description && formik.errors.description
-                    }
+										helperText={
+											(formik.errors.description ? formik.touched.description && formik.errors.description :
+											`${formik.values.description.length} / 1030 caracteres`)
+										}
                   />
                 </Paper>
                 <Paper
@@ -295,10 +329,11 @@ export const CreateEditPackageDetails = () => {
                       formik.touched.itinerary &&
                       Boolean(formik.errors.itinerary)
                     }
-                    helperText={
-                      formik.touched.itinerary && formik.errors.itinerary
-                    }
-                  />
+										helperText={
+											(formik.errors.itinerary ? formik.touched.itinerary && formik.errors.itinerary :
+											`${formik.values.itinerary.length} / 10000 caracteres`)
+										}
+									/>
                 </Paper>
               </Box>
               
@@ -412,10 +447,10 @@ export const CreateEditPackageDetails = () => {
                     formik.touched.included_services &&
                     Boolean(formik.errors.included_services)
                   }
-                  helperText={
-                    formik.touched.included_services &&
-                    formik.errors.included_services
-                  }
+									helperText={
+										(formik.errors.included_services ? formik.touched.included_services && formik.errors.included_services :
+										`${formik.values.included_services.length} / 320 caracteres`)
+									}
                 />
               </Paper>
             </Box>
@@ -467,27 +502,36 @@ export const CreateEditPackageDetails = () => {
               <Button
                 type="button"
                 variant="contained"
-                onClick={handleGuardar}
+								disabled={
+                  disabledButton ||  // Si el fetch está en progreso 
+                  !formik.isValid ||  // Si el formulario no es válido
+                  (isNewPackage && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
+                }
+								onClick={(e) => handleSiguiente(e, false)}
                 sx={{
                   backgroundColor: "#fff",
                   width: "100%",
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                Guardar
+                Actualizar Paquete
               </Button>
               <Button
                 variant="contained"
-                disabled={disabledButton}
+                disabled={
+                  disabledButton ||  // Si el fetch está en progreso 
+                  !formik.isValid ||  // Si el formulario no es válido
+                  (isNewPackage && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
+                }
                 type="button"
-                onClick={handleSiguiente}
+								onClick={(e) => handleSiguiente(e, true)}
                 sx={{
                   backgroundColor: "#72CCA0",
                   width: "100%",
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                {params.id ? "Actualizar Paquete" : "Siguiente"}
+                Guardar y Siguiente
               </Button>
             </Box>
 

--- a/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
+++ b/Front/src/modules/admin/pages/CreateEditPackageDetails.jsx
@@ -1,4 +1,4 @@
-// @modules/admin/components/CreateEditPackage.jsx
+// @modules/admin/components/CreateEditPackageDetails.jsx
 import { useState, useCallback, useEffect } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -13,6 +13,7 @@ import {
   Typography,
   Paper,
   styled,
+  CircularProgress,
 } from "@mui/material";
 import {
   getPackageById,
@@ -37,8 +38,8 @@ export const CreateEditPackageDetails = () => {
 	const params = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const isNewPackage = location.state ? location.state?.isNewPackage : false;
-	
+  const isNewPackage = location.state ? location.state?.isNewPackage : {};
+
   const paqueteSchema = () =>
     Yup.object().shape({
       description: Yup.string()
@@ -59,7 +60,7 @@ export const CreateEditPackageDetails = () => {
         .required("Los servicios incluidos son requeridos")
         .max(320, "Los servicios incluidos no pueden superar los 320 caracteres"),
       itineraryPhoto: Yup.mixed().when([], {
-        is: () => isNewPackage, // Si params.id NO existe (es creación)
+        is: () => isNewPackage && Object.keys(isNewPackage).length !== 0, // Si params.id NO existe (es creación)
         then: (schema) =>
           schema
             .required('La imagen de itinerario es requerida')
@@ -85,11 +86,10 @@ export const CreateEditPackageDetails = () => {
 
   const getPackById = useCallback(
 		async (id) => {
-			if(isNewPackage) return;
+			if (isNewPackage && Object.keys(isNewPackage).length !== 0) return;
       try {
         const { data: dataPackages } = await getPackageById(id);
         setPackage(dataPackages.data);
-				console.log('dataPackages.data', dataPackages.data);
         formik.setValues({
 					id: +params.id,
 					idCategory: dataPackages.data.category.id,
@@ -121,8 +121,8 @@ export const CreateEditPackageDetails = () => {
 
   const formik = useFormik({
     initialValues: {
-			id: "",
-			idCategory: "",
+			id: +params.id,
+			idCategory: isNewPackage?.categoryId || "",
       description: "",
       itinerary: "",
       duration: "",
@@ -141,7 +141,6 @@ export const CreateEditPackageDetails = () => {
 	const sendPackages = (values) => {
       // funcion para enviar formulario de texto
 			setDisabledButton(true);
-      console.log("formModified", formModified)
       if(formModified){
         if(!formik.validateForm()) return
         sendEditPackages(values)
@@ -153,7 +152,6 @@ export const CreateEditPackageDetails = () => {
   };
 
 	const sendEditPackages = useCallback(async (values) => {
-		console.log('formik.values', formik.values);
 		const dataToSend = {
 			id: +params.id,
 			idCategory: values.idCategory,
@@ -178,6 +176,7 @@ export const CreateEditPackageDetails = () => {
         included_services: values.included_services,
         itineraryPhoto: values.itineraryPhoto,
       });
+      setFormModified(false);
     } catch (error) {
       console.error(`Error al actualizar el paquete:`, error);
       NotificationService.error(`Error al actualizar el paquete`, 2200);
@@ -189,10 +188,10 @@ export const CreateEditPackageDetails = () => {
     try {
       await sendPackages(formik.values);
       if (moveForward) {
-        if (!isNewPackage) {
-					navigate(params.id && `/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: false}});
+        if (isNewPackage && Object.keys(isNewPackage).length === 0) {
+					navigate(params.id && `/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: {}}});
 				} else {
-					navigate(`/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: true}}); 
+					navigate(`/admin/paquetes/destinos/${params.id}`, {state: {isNewPackage: {id: isNewPackage.id, categoryId: isNewPackage.categoryId}}}); 
 				}
       }
     } catch (error) {
@@ -208,7 +207,7 @@ export const CreateEditPackageDetails = () => {
     try {
       // Pasar el packageId y formData
       const response = await postSimpleImagePackages(packID, formData); // Axios devuelve 'data' directamente
-        console.log('response', response);
+        console.log('La imagen fue cargada con éxito');
         NotificationService.success('La imagen fue cargada con éxito');
     } catch (error) {
         console.error(error);
@@ -491,7 +490,8 @@ export const CreateEditPackageDetails = () => {
 								disabled={
                   disabledButton ||  // Si el fetch está en progreso 
                   !formik.isValid ||  // Si el formulario no es válido
-                  (isNewPackage && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
+                  !formModified ||
+                  (isNewPackage && Object.keys(isNewPackage).length !== 0 && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
                 }
 								onClick={(e) => handleSiguiente(e, false)}
                 sx={{
@@ -500,14 +500,17 @@ export const CreateEditPackageDetails = () => {
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                Actualizar Paquete
+                {disabledButton 
+                ? <CircularProgress size={20} color="inherit" /> 
+                : "Actualizar Paquete"}
               </Button>
               <Button
                 variant="contained"
                 disabled={
                   disabledButton ||  // Si el fetch está en progreso 
                   !formik.isValid ||  // Si el formulario no es válido
-                  (isNewPackage && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
+                  !formModified ||
+                  (isNewPackage && Object.keys(isNewPackage).length !== 0 && !formik.dirty)  // Si el formulario es nuevo paquete debe estar completo
                 }
                 type="button"
 								onClick={(e) => handleSiguiente(e, true)}
@@ -517,7 +520,9 @@ export const CreateEditPackageDetails = () => {
                   transition: "transform 0.3s ease-in-out",
                 }}
               >
-                Guardar y Siguiente
+                {disabledButton 
+                ? <CircularProgress size={20} color="inherit" /> 
+                : "Guardar y Siguiente"}
               </Button>
             </Box>
 


### PR DESCRIPTION
Introduce mejoras y correcciones en los componentes relacionados con la creación y edición de paquetes en Admin.

✨ Nuevas funcionalidades y mejoras

XX CreateEditPackageBasic:
-Se agrega validación mínima al campo name.
-Se reorganizan los parámetros del POST del banner.
-Se añade un loading al botón de carga y se deshabilitan los botones al finalizar el proceso.
-Se corrige la toma del dato active.
-isNewPackage ahora es un objeto.

XX CreateEditPackageDetails:
-Se unifica la lógica con CreateEditPackageBasic.
-Se diferencian los botones según si es un nuevo paquete (isNewPackage).
-Se hacen obligatorios todos los campos excepto itineraryPhoto (manejo distinto en edición).
-Se agrega loading al botón de carga y se deshabilitan los botones al finalizar.
-Se acepta isNewPackage como objeto y se pasa a initialValues.
-Al iniciar, carga los datos del paquete y actualiza imagePreview.

XX CreateEditPackage:
-Se reestructura la tarjeta de "Add Images", ahora aparece al principio.
-Se especifica el schema, agregando el manejo de imágenes y sus llamadas a la API.
-Se corrigen las IDs de las imágenes en el formulario.
-El manejo de imágenes se unifica con CreateEditPackageDetails.

XX packageApi:
-Se agrega el endpoint putImagePackagesById.
-Se corrigen dos endpoints para un funcionamiento adecuado.

🛠 Correcciones menores
-Eliminación de console.log innecesarios.
-Ajustes en la estructura y orden del código.