### PR TITLE
Corrección del problema al cargar la salidas

### DIFF
--- a/Front/src/modules/Departures/components/TruncatedText.jsx
+++ b/Front/src/modules/Departures/components/TruncatedText.jsx
@@ -28,6 +28,7 @@ const TruncatedText = ({ text }) => {
       <Box
         sx={{
           overflow: "hidden",
+          textAlign: "center",
         }}
       >
         <Typography

--- a/Front/src/modules/Departures/utils/utils.jsx
+++ b/Front/src/modules/Departures/utils/utils.jsx
@@ -163,7 +163,7 @@ export const usePackageById = (packageId) => {
     return () => {
       isMounted = false;
     };
-  }, [packageId, updateSharedPack]); // updateSharedPack removido de las dependencias
+  }, [packageId]); // updateSharedPack removido de las dependencias
 
   return { pack, isLoading, error };
 };


### PR DESCRIPTION
fix(utils):  removiendo dependencia updateSharedPack del hook usePackageById  que traía problemas al cargar la salida

fix(TruncatedText): centrado del texto del itinerario